### PR TITLE
Make webpage port controllable by environment variable

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,8 +39,9 @@ wss.on("connection", function wsConnection(ws) {
 	});
 });
 
+const web_port = parseInt(process.env?.IRC_WEBCHAT_PORT);
 
-app.listen(80, () => {
+app.listen(isNaN(web_port) ? 80 : web_port, () => {
 	console.log("Successfully started meta-IRC page.");
 });
 


### PR DESCRIPTION
This allows hosting the webpage on ports other than port 80, which not all systems are able to host on.  By setting the environment variable "IRC_WEBCHAT_PORT", the port can be changed to whatever is specified by the environment variable. Eventually, we may want to change this to read from a config.json file if we have a lot of options that can be set.